### PR TITLE
Link corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,26 @@ At that point, you can then use PyScript components in your html page. PyScript 
 
 Check out the [pyscriptjs/examples](pyscriptjs/examples) folder for more examples on how to use it, all you need to do is open them in Chrome.
 
+If you are trying to open the examples in the Chrome then try to change the `pyscript.js` and `pyscript.css` local reference to the CDN one that mentioned above (https://pyscript.net/alpha/pyscript.js, https://pyscript.net/alpha/pyscript.css).
+
+For example:
+
+In the `hello_world.html` file,
+
+Change the following lines 
+
+```
+<link rel="stylesheet" href="build/pyscript.js" /> 
+<script defer src="build/pyscript.js"></script>
+```
+
+with remote cdn links.
+
+```
+<link rel="stylesheet" href="https://pyscript.net/alpha/pyscript.css" />
+<script defer src="https://pyscript.net/alpha/pyscript.js"></script>
+```
+
 ## How to Contribute
 
 To contribute:

--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ For example:
 
 In the `hello_world.html` file,
 
-Change the following lines 
+Change the following lines
 
 ```
-<link rel="stylesheet" href="build/pyscript.js" /> 
+<link rel="stylesheet" href="build/pyscript.js" />
 <script defer src="build/pyscript.js"></script>
 ```
 

--- a/pyscriptjs/README.md
+++ b/pyscriptjs/README.md
@@ -35,6 +35,28 @@ A simple webapp to demonstrate the capabilities of PyScript.
    [http://localhost:8080](http://localhost:8080). This will provide a list of
    demos that you can run.
 
+
+   You can take the examples folder and change the `pyscript.js` and `pyscript.css` local reference to the CDN one that mentioned above to run the examples indivitually on the browser.
+
+   **For example:**
+
+   In the hello_world.html file,
+
+   Change the following lines 
+
+   ```
+   <link rel="stylesheet" href="build/pyscript.js" /> 
+   <script defer src="build/pyscript.js"></script>
+   ```
+
+   with remote cdn links.
+
+   ```
+   <link rel="stylesheet" href="https://pyscript.net/alpha/pyscript.css" />
+   <script defer src="https://pyscript.net/alpha/pyscript.js"></script>
+   ```
+
+
 ## More information
 
 There is a forum PyScript where you can discuss the project or ask questions at [https://community.anaconda.cloud/c/pyscript](https://community.anaconda.cloud/c/pyscript)

--- a/pyscriptjs/README.md
+++ b/pyscriptjs/README.md
@@ -42,10 +42,10 @@ A simple webapp to demonstrate the capabilities of PyScript.
 
    In the hello_world.html file,
 
-   Change the following lines 
+   Change the following lines
 
    ```
-   <link rel="stylesheet" href="build/pyscript.js" /> 
+   <link rel="stylesheet" href="build/pyscript.js" />
    <script defer src="build/pyscript.js"></script>
    ```
 

--- a/pyscriptjs/examples/altair.html
+++ b/pyscriptjs/examples/altair.html
@@ -3,8 +3,8 @@
     <title>Altair</title>
     <meta charset="utf-8">
 
-    <link rel="stylesheet" href="../build/pyscript.css" />
-    <script defer src="../build/pyscript.js"></script>
+    <link rel="stylesheet" href="build/pyscript.css" />
+    <script defer src="build/pyscript.js"></script>
     <py-env>
       - altair
       - pandas

--- a/pyscriptjs/examples/antigravity.html
+++ b/pyscriptjs/examples/antigravity.html
@@ -3,8 +3,8 @@
     <title>Antigravity</title>
     <meta charset="utf-8">
 
-    <link rel="stylesheet" href="../build/pyscript.css" />
-    <script defer src="../build/pyscript.js"></script>
+    <link rel="stylesheet" href="build/pyscript.css" />
+    <script defer src="build/pyscript.js"></script>
   </head>
   <py-env>
 - paths:

--- a/pyscriptjs/examples/bokeh.html
+++ b/pyscriptjs/examples/bokeh.html
@@ -11,9 +11,9 @@
     <script type="text/javascript">
         Bokeh.set_log_level("info");
     </script>
-    <link rel="stylesheet" href="../build/pyscript.css" />
+    <link rel="stylesheet" href="build/pyscript.js" />
 
-    <script defer src="../build/pyscript.js"></script>
+    <script defer src="build/pyscript.js"></script>
 
     </head>
     <body>

--- a/pyscriptjs/examples/bokeh_interactive.html
+++ b/pyscriptjs/examples/bokeh_interactive.html
@@ -11,9 +11,9 @@
     <script type="text/javascript">
         Bokeh.set_log_level("info");
     </script>
-    <link rel="stylesheet" href="../build/pyscript.css" />
+    <link rel="stylesheet" href="build/pyscript.css" />
 
-    <script defer src="../build/pyscript.js"></script>
+    <script defer src="build/pyscript.js"></script>
 
     </head>
     <body>

--- a/pyscriptjs/examples/d3.html
+++ b/pyscriptjs/examples/d3.html
@@ -3,8 +3,8 @@
     <title>d3: JavaScript & PyScript visualizations side-by-side</title>
     <meta charset="utf-8">
 
-    <link rel="stylesheet" href="../build/pyscript.css" />
-    <script defer src="../build/pyscript.js"></script>
+    <link rel="stylesheet" href="build/pyscript.js" />
+    <script defer src="build/pyscript.js"></script>
 
     <style>
     .loading {

--- a/pyscriptjs/examples/folium.html
+++ b/pyscriptjs/examples/folium.html
@@ -3,8 +3,8 @@
     <title>Folium</title>
     <meta charset="utf-8">
 
-    <link rel="stylesheet" href="../build/pyscript.css" />
-    <script defer src="../build/pyscript.js"></script>
+    <link rel="stylesheet" href="build/pyscript.js" />
+    <script defer src="build/pyscript.js"></script>
     <py-env>
       - folium
       - pandas

--- a/pyscriptjs/examples/handtrack/say_hello.html
+++ b/pyscriptjs/examples/handtrack/say_hello.html
@@ -7,9 +7,9 @@
     <title>Svelte app</title>
 
     <link rel="icon" type="image/png" href="favicon.png" />
-    <link rel="stylesheet" href="../../build/pyscript.css" />
+    <link rel="stylesheet" href="../build/pyscript.js" />
 
-    <script defer src="../../build/pyscript.js"></script>
+    <script defer src="../build/pyscript.js"></script>
   </head>
 
   <body>

--- a/pyscriptjs/examples/hello_world.html
+++ b/pyscriptjs/examples/hello_world.html
@@ -7,9 +7,9 @@
     <title>PyScript Hello World</title>
 
     <link rel="icon" type="image/png" href="favicon.png" />
-    <link rel="stylesheet" href="../build/pyscript.css" />
+    <link rel="stylesheet" href="build/pyscript.js" />
 
-    <script defer src="../build/pyscript.js"></script>
+    <script defer src="build/pyscript.js"></script>
   </head>
 
   <body>

--- a/pyscriptjs/examples/mario/play_mario.html
+++ b/pyscriptjs/examples/mario/play_mario.html
@@ -7,9 +7,9 @@
     <title>Svelte app</title>
 
     <link rel="icon" type="image/png" href="../favicon.png" />
-    <link rel="stylesheet" href="../../build/pyscript.css" />
+    <link rel="stylesheet" href="../build/pyscript.js" />
 
-    <script defer src="../../build/pyscript.js"></script>
+    <script defer src="../build/pyscript.js"></script>
   </head>
 
   <body>

--- a/pyscriptjs/examples/matplotlib.html
+++ b/pyscriptjs/examples/matplotlib.html
@@ -3,8 +3,8 @@
     <title>Matplotlib</title>
     <meta charset="utf-8">
 
-    <link rel="stylesheet" href="../build/pyscript.css" />
-    <script defer src="../build/pyscript.js"></script>
+    <link rel="stylesheet" href="build/pyscript.js" />
+    <script defer src="build/pyscript.js"></script>
     <py-env>
       - matplotlib
     </py-env>

--- a/pyscriptjs/examples/micrograd_ai.html
+++ b/pyscriptjs/examples/micrograd_ai.html
@@ -6,8 +6,8 @@
 
         <title>micrograd</title>
 
-        <link rel="stylesheet" href="../build/pyscript.css" />
-        <script defer src="../build/pyscript.js"></script>
+        <link rel="stylesheet" href="build/pyscript.js" />
+        <script defer src="build/pyscript.js"></script>
 
         <py-env>
             - micrograd

--- a/pyscriptjs/examples/numpy_canvas_fractals.html
+++ b/pyscriptjs/examples/numpy_canvas_fractals.html
@@ -3,8 +3,8 @@
     <title>Visualization of Mandelbrot, Julia and Newton sets with NumPy and HTML5 canvas</title>
     <meta charset="utf-8">
 
-    <link rel="stylesheet" href="../build/pyscript.css" />
-    <script defer src="../build/pyscript.js"></script>
+    <link rel="stylesheet" href="build/pyscript.js" />
+    <script defer src="build/pyscript.js"></script>
 
     <style>
       .loading {

--- a/pyscriptjs/examples/panel.html
+++ b/pyscriptjs/examples/panel.html
@@ -7,8 +7,8 @@
     <script type="text/javascript" src="https://cdn.bokeh.org/bokeh/release/bokeh-widgets-2.4.2.min.js"></script>
     <script type="text/javascript" src="https://cdn.bokeh.org/bokeh/release/bokeh-tables-2.4.2.min.js"></script>
     <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/@holoviz/panel@0.13.0-rc.10/dist/panel.min.js"></script>
-    <link rel="stylesheet" href="../build/pyscript.css" />
-    <script defer src="../build/pyscript.js"></script>
+    <link rel="stylesheet" href="build/pyscript.js" />
+    <script defer src="build/pyscript.js"></script>
   </head>
   <body>
     <py-env>

--- a/pyscriptjs/examples/panel_deckgl.html
+++ b/pyscriptjs/examples/panel_deckgl.html
@@ -38,8 +38,8 @@
 	  width: 400px;
       }
     </style>
-    <link rel="stylesheet" href="../build/pyscript.css" />
-    <script defer src="../build/pyscript.js"></script>
+    <link rel="stylesheet" href="build/pyscript.js" />
+    <script defer src="build/pyscript.js"></script>
   </head>
   <body>
     <py-env>

--- a/pyscriptjs/examples/panel_kmeans.html
+++ b/pyscriptjs/examples/panel_kmeans.html
@@ -40,8 +40,8 @@
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.5.1/dist/jquery.slim.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.1/dist/js/bootstrap.bundle.min.js"></script>
 
-    <link rel="stylesheet" href="../build/pyscript.css" />
-    <script defer src="../build/pyscript.js"></script>
+    <link rel="stylesheet" href="build/pyscript.js" />
+    <script defer src="build/pyscript.js"></script>
   </head>
 
   <py-env>

--- a/pyscriptjs/examples/repl.html
+++ b/pyscriptjs/examples/repl.html
@@ -7,8 +7,8 @@
     <title>REPL</title>
 
     <link rel="icon" type="image/png" href="favicon.png" />
-    <link rel="stylesheet" href="../build/pyscript.css" />
-    <script defer src="../build/pyscript.js"></script>
+    <link rel="stylesheet" href="build/pyscript.js" />
+    <script defer src="build/pyscript.js"></script>
   </head>
 
   <py-env>

--- a/pyscriptjs/examples/repl2.html
+++ b/pyscriptjs/examples/repl2.html
@@ -7,10 +7,10 @@
     <title>Custom REPL Example</title>
 
     <link rel="icon" type="image/png" href="favicon.png" />
-    <link rel="stylesheet" href="../build/pyscript.css" />
+    <link rel="stylesheet" href="build/pyscript.js" />
     <link rel="stylesheet" href="repl.css" />
 
-    <script defer src="../build/pyscript.js"></script>
+    <script defer src="build/pyscript.js"></script>
   </head>
 
   <py-env>

--- a/pyscriptjs/examples/simple_clock.html
+++ b/pyscriptjs/examples/simple_clock.html
@@ -7,9 +7,9 @@
     <title>Simple Clock Demo</title>
 
     <link rel="icon" type="image/png" href="favicon.png" />
-    <link rel="stylesheet" href="../build/pyscript.css" />
+    <link rel="stylesheet" href="build/pyscript.js" />
 
-    <script defer src="../build/pyscript.js"></script>
+    <script defer src="build/pyscript.js"></script>
     <py-env>
     - paths:
       - ./utils.py

--- a/pyscriptjs/examples/todo-pylist.html
+++ b/pyscriptjs/examples/todo-pylist.html
@@ -6,14 +6,14 @@
     <title>Todo App</title>
 
     <link rel="icon" type="image/png" href="favicon.png" />
-    <link rel="stylesheet" href="/build/pyscript.css" />
+    <link rel="stylesheet" href="build/pyscript.css" />
 
-    <script defer src="/build/pyscript.js"></script>
+    <script defer src="build/pyscript.js"></script>
     <py-env>
     - paths:
       - ./utils.py
     </py-env>
-    <py-register-widget src="/pylist.py" name="py-list" klass="PyList"></py-register-widget>
+    <py-register-widget src="pylist.py" name="py-list" klass="PyList"></py-register-widget>
 
     <py-script>
       def add_task(*ags, **kws):

--- a/pyscriptjs/examples/todo.html
+++ b/pyscriptjs/examples/todo.html
@@ -7,9 +7,9 @@
     <title>Todo App</title>
 
     <link rel="icon" type="image/png" href="favicon.png" />
-    <link rel="stylesheet" href="/build/pyscript.css" />
+    <link rel="stylesheet" href="build/pyscript.css" />
 
-    <script defer src="/build/pyscript.js"></script>
+    <script defer src="build/pyscript.js"></script>
     <py-env>
     - paths:
       - ./utils.py
@@ -18,7 +18,7 @@
 
   <body class="container">
     <!-- <py-repl id="my-repl" auto-generate="true"> </py-repl> -->
-  <py-script src="/todo.py">  </py-script>
+  <py-script src="todo.py">  </py-script>
 
   <main class="max-w-xs mx-auto mt-4">
     <section>

--- a/pyscriptjs/examples/webgl/raycaster/index.html
+++ b/pyscriptjs/examples/webgl/raycaster/index.html
@@ -21,8 +21,8 @@
   </div>
 <script src='https://cdnjs.cloudflare.com/ajax/libs/three.js/89/three.min.js'></script>
 
-<script defer src="/build/pyscript.js"></script>
-<link rel="stylesheet" href="/build/pyscript.css" />
+<script defer src="../build/pyscript.js"></script>
+<link rel="stylesheet" href="../build/pyscript.css" />
 <script>
 
 </script>


### PR DESCRIPTION
The local pyscript.js and pyscript.css file links were broken and referred to the wrong path due to the build path changes. So, the relative path to the local pyscript.js and pyscript.css file references are changed to resolve this issue. 
Also, provided the steps to run the examples directly on Chrome by changing the local reference to cdn links. 
